### PR TITLE
Change timestamp implementation of 'stats' API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# macOS files
+.DS_Store

--- a/public/_headers
+++ b/public/_headers
@@ -1,2 +1,3 @@
+#ping-placeholder
 /*
   Access-Control-Allow-Origin: https://kawalcovid19.id

--- a/src/ping.js
+++ b/src/ping.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const now = Date.now();
 console.log(`Now is ${new Date(now).toGMTString()}`);
 
-const headerConfig = ['/ping', ' X-Update-Timestamp: ' + now.toString()].join('\n');
-fs.writeFileSync('public/_headers', headerConfig);
+const headers = fs.readFileSync('public/_headers', 'utf-8').toString();
+const pingHeaders = ['/ping', '  X-Update-Timestamp: ' + now.toString()].join('\n');
+const modifiedHeaders = headers.replace('#ping-placeholder', pingHeaders);
+fs.writeFileSync('public/_headers', modifiedHeaders);
 fs.writeFileSync('public/ping', 'OK');

--- a/src/progress-national.jq
+++ b/src/progress-national.jq
@@ -1,13 +1,16 @@
-[
-    .update | .harian | .[] |
-    {
-        type: "country",
-        name: "Indonesia",
-        timestamp: .key,
-        numbers: {
-            infected: .jumlah_positif_kum .value,
-            recovered: .jumlah_sembuh_kum .value,
-            fatal: .jumlah_meninggal_kum .value
+{
+    updatedAt: .update .penambahan .created,
+    history: [
+        .update | .harian | .[] |
+        {
+            type: "country",
+            name: "Indonesia",
+            timestamp: .key,
+            numbers: {
+                infected: .jumlah_positif_kum .value,
+                recovered: .jumlah_sembuh_kum .value,
+                fatal: .jumlah_meninggal_kum .value
+            }
         }
-    }
-]
+    ]
+}

--- a/src/stats.js
+++ b/src/stats.js
@@ -30,11 +30,14 @@ function updateCovid19Stats(metadata) {
     updateNational();
     updateProvinces();
 
-    const progressNationalStats = JSON.parse(fs.readFileSync(prefix + 'progress-national.json', 'utf-8').toString())
+    const progressNationalRaw = JSON.parse(fs.readFileSync(prefix + 'progress-national.json', 'utf-8').toString())
+    const progressNationalStats = progressNationalRaw.history
         .filter((s) => s.name === 'Indonesia')
         .filter((s) => s.numbers && typeof s.numbers.infected === 'number')
         .sort((p, q) => p.timestamp - q.timestamp);
     const nationalStats = progressNationalStats.slice(-1).pop();
+    // updatedAt is of Jakarta time (WIB, GMT+7) in 'YYYY-MM-DD HH:mm:ss' format
+    const updatedAt = Date.parse(progressNationalRaw.updatedAt.concat('+0700'));
 
     const provincesStats = JSON.parse(fs.readFileSync(prefix + 'provinces.json', 'utf-8').toString())
         .filter((p) => p.name !== 'Indonesia')
@@ -50,7 +53,7 @@ function updateCovid19Stats(metadata) {
         .sort((p, q) => p.name.localeCompare(q.name));
     fs.writeFileSync(prefix + 'provinces.json', JSON.stringify(provincesStats, null, 2));
 
-    const stats = { ...nationalStats, regions: provincesStats.sort((p, q) => q.numbers.infected - p.numbers.infected) };
+    const stats = { ...nationalStats, timestamp: updatedAt, regions: provincesStats.sort((p, q) => q.numbers.infected - p.numbers.infected) };
     fs.writeFileSync(prefix + 'stats', JSON.stringify(stats, null, 2));
 
     const timestampName = prefix + 'stats.timestamp';


### PR DESCRIPTION
Taken from '.update.penambahan.created' in 'public/api/cache/update.json'.
Previous JSON structure of 'public/api/id/covid19/progress-national.json' are moved down as '.history'.